### PR TITLE
【FIX #42】メイン画像だけでなく、サブ写真を追加できるようにする。

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -65,6 +65,7 @@ class ProductsController < ApplicationController
       :harvest_date,
       :farm_name,
       :farm_street_address,
+      sub_images: [],
       label_ids: [])
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,6 @@
 class Product < ApplicationRecord
   has_one_attached :image
+  has_many_attached :sub_images
   has_many :favorites, dependent: :destroy
   has_many :favorite_users, through: :favorites, source: :user
   has_many :labelings, dependent: :destroy

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -31,6 +31,10 @@
       <i class="far fa-image"> メイン画像ファイルを選択</i>
     <% end %>
     <%= form.file_field :image, class: "image_form", style: "display: none;"%>
+    <%= form.label :sub_images, class: "btn btn-warning" do %>
+      <i class="far fa-image"> サブ画像ファイルを選択(3枚まで)</i>
+    <% end %>
+    <%= form.file_field :sub_images, class: "image_form", multiple: true, style: "display: none;"%>
   </div>
 
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
-  <div class="mx-auto p-4 my-4 border border-primary rounded" style="border:solid 1px; max-width:900px;">
+  <div class="mx-auto p-4 my-4 border border-primary rounded" style="border:solid 1px; max-width:1000px;">
     <h2>商品詳細画面</h2>
     <div class="alert alert-light" role="alert">
       <p id="notice"><%= notice %></p>
     </div>
-    <div class="product-text rounded" style="ax-width:900px;">
+    <div class="product-text rounded" style="ax-width:1000px;">
       <div class="row ml-2 mb-2 mr-2">
         <div class="row mr-2">
         <% if @product.image.attached? %>
@@ -53,7 +53,7 @@
     <% end %>
   </div>
   <br>
-  <div class="card mx-auto border border-primary rounded" style="max-width:900px;">
+  <div class="card mx-auto border border-primary rounded" style="max-width:1000px;">
     <div class="card-body p-4">
       <div class="text-center my-3">
         <strong>コメント一覧</strong>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,15 +1,26 @@
 <div class="container">
-  <div class="mx-auto p-4  border border-primary rounded" style="border:solid 1px; max-width:700px;">
+  <div class="mx-auto p-4 my-4 border border-primary rounded" style="border:solid 1px; max-width:900px;">
     <h2>商品詳細画面</h2>
     <div class="alert alert-light" role="alert">
       <p id="notice"><%= notice %></p>
     </div>
-    <div class="product-text rounded" style="ax-width:700px;">
-      <% if @product.image.attached? %>
-        <p>
-          <%= image_tag @product.image.variant(combine_options:{gravity: :center,border:'2', resize:"180x180^",crop:"220x220+0+0"}).processed ,class: "rounded"%>
-        </p>
-      <% end %>
+    <div class="product-text rounded" style="ax-width:900px;">
+      <div class="row ml-2 mb-2 mr-2">
+        <div class="row mr-2">
+        <% if @product.image.attached? %>
+          <p>
+            <%= image_tag @product.image.variant(combine_options:{gravity: :center,border:'2', resize:"180x180^",crop:"220x220+0+0"}).processed ,class: "rounded"%>
+          </p>
+        <% end %>
+        </div>
+        <% if @product.sub_images.attached? %>
+          <p>
+            <% @product.sub_images.first(3).each do |sub_image| %>
+              <%= image_tag sub_image.variant(combine_options:{gravity: :center,border:'2', resize:"180x180^",crop:"220x220+0+0"}).processed ,class: "rounded"%>
+            <% end %>
+          </p>
+        <% end %>
+      </div>
       <p class="form-control border border-primary rounded"><%= @product.title %></p>
       <p>
         <% @product.labels.each do |label| %>
@@ -42,7 +53,7 @@
     <% end %>
   </div>
   <br>
-  <div class="card mx-auto border border-primary rounded" style="max-width:700px;">
+  <div class="card mx-auto border border-primary rounded" style="max-width:900px;">
     <div class="card-body p-4">
       <div class="text-center my-3">
         <strong>コメント一覧</strong>


### PR DESCRIPTION
- [ ]メイン画像だけでなく、サブ写真を追加できるようにする。
→詳細画面のみにサブ写真が写るようにした。