### PR TITLE
【FIX #56】バリデーションの管理

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,10 +11,23 @@ class Product < ApplicationRecord
   validates :title, presence: true ,length: { maximum: 25 }
   validates :price, presence: true
   validates :quantity, presence: true
+  validate :image_presence
   validates :content, presence:true ,length: { maximum: 300 }
+  validates :harvest_date, presence:true
+  validate :date_not_after_today
   validates :farm_name, presence:true
   validates :farm_street_address, presence:true
 
+  def image_presence
+    if image.attached?
+    else
+      errors.add(:image, 'ファイルを添付してください')
+    end
+  end
+
+  def date_not_after_today
+    errors.add(:harvest_date, "は本日以前のものを選択してください") if harvest_date.nil? || harvest_date > Date.today
+  end
 
   scope :title_search, -> (title) {where("title LIKE ?", "%#{title}%")}
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -81,6 +81,9 @@
           </div>
         </nav>
       </header>
+      <div style="height:40px;">
+        <%= render "layouts/flash" %>
+      </div>
       <%= yield %>
       <footer class="fixed-bottom bg-success d-block">
         <div class="container my-2">

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,6 +1,3 @@
-<div style="height:40px;">
-  <%= render "layouts/flash" %>
-</div>
 <div class="slider">
   <% @products.shuffle.first(6).each do |product|%>
     <% if product.image.attached? %>

--- a/db/migrate/20200819081959_change_columns_add_notnull_on_products.rb
+++ b/db/migrate/20200819081959_change_columns_add_notnull_on_products.rb
@@ -1,0 +1,5 @@
+class ChangeColumnsAddNotnullOnProducts < ActiveRecord::Migration[5.2]
+  def change
+    change_column :products, :harvest_date, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_13_111534) do
+ActiveRecord::Schema.define(version: 2020_08_19_081959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,7 +118,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_111534) do
     t.integer "price", null: false
     t.integer "quantity", null: false
     t.text "content", null: false
-    t.datetime "harvest_date"
+    t.datetime "harvest_date", null: false
     t.string "farm_name", null: false
     t.string "farm_street_address", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
- [ ] harvest_dateにバリデーションを組む&日付が作成日より後の日付の時、エラーが出るようにした。
- [ ] productを作成するためのimage(activestrageで作成)がなかった場合、エラーが出るようにした。
- [ ] メッセージ(layouts/flash)を全体に反映させるように変更。