### PR TITLE
【FIX #81】消費者側のメッセージ一覧の修正&検索機能の修正

### DIFF
--- a/app/views/message_tops/index.html.erb
+++ b/app/views/message_tops/index.html.erb
@@ -1,7 +1,7 @@
 <br/>
 <div class="mx-auto p-4 border border-primary rounded" style="border:solid 1px #343a40; max-width:700px; margin-top:30px;">
   <% if user_signed_in? %>
-    <h5 class="text-center home_title" style="margin-bottom:30px;">生産者一覧</h5>
+    <h5 class="text-center home_title text-primary" style="margin-bottom:30px;">生産者一覧</h5>
     <br>
     <% @producers.each do |producer| %>
       <% if producer.producer_avatar.attached? %>
@@ -11,13 +11,13 @@
                                                             crop:"220x220+0+0"}).processed,
                                                             class: "img border-primary image_size"%>
       <% end %>
-      <%= producer.producer_name %>さん
+        <p class="alert alert-warning rounded"><%= producer.producer_name %>さん</p>
       <% if @producer_ids.include?(producer.id) %>
-        <%= link_to "チャットへ", room_path(current_user.rooms.find_by(producer_id: producer.id)) , class: " btn btn-primary"%><br><br/>
+        <%= link_to "チャットへ", room_path(current_user.rooms.find_by(producer_id: producer.id)) , class: "btn btn-primary position-relative", style: "bottom:60px; left:530px;"%><br/>
       <% else %>
         <%= form_for Room.new do |f| %>
           <%= f.hidden_field :producer_id, :value => producer.id %>
-          <%= f.submit  class: "btn btn-primary", id: "createroom"%>
+          <%= f.submit  class: "btn btn-primary position-relative" ,id: "createroom" ,style: "bottom:60px; left:545px;"%>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -60,7 +60,7 @@
           <%= form.label :label_id_search, class: "text-primary" do %>
             <i class="fas fa-tags"> ラベル検索</i>
           <% end %><br/>
-          <%= form.select("label_id", Label.all.pluck(:name, :id), { include_blank:"選択する",include_hidden: false },  {  class: "form-control", required: true }) %><br/>
+          <%= form.select("label_id", Label.all.pluck(:name, :id), { include_blank:"選択する",include_hidden: false },  {  class: "form-control" }) %><br/>
           <%= form.hidden_field :search, value:"true" %>
           <%= form.submit name="検索する" , class: "form-control btn btn-info"%>
         <% end %>


### PR DESCRIPTION
- [ ] 消費者側のメッセージ一覧ページが生産者側と異なっていたため修正。
- [ ] タイトル検索が単体でできなかったため、修正。