### PR TITLE
【FIX #83】商品投稿画面の修正

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -56,7 +56,7 @@
   </div>
 
   <div class="form-group">
-    <%= form.label :farm_street_address %><br />
+    <%= form.label :farm_street_address ,class: "text-primary" %><br />
     <%= form.text_field :farm_street_address, autoformocus: true , class: "form-control" %>
   </div>
 


### PR DESCRIPTION
- [ ] 商品投稿画面の"住所"の文字の色が統一されていなかったため、修正。