### PR TITLE
【FIX #99】生産者のお気に入り機能を作る

### DIFF
--- a/app/assets/javascripts/favorite_persons.coffee
+++ b/app/assets/javascripts/favorite_persons.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/favorite_persons.scss
+++ b/app/assets/stylesheets/favorite_persons.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the favorite_persons controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/favorite_persons_controller.rb
+++ b/app/controllers/favorite_persons_controller.rb
@@ -1,0 +1,17 @@
+class FavoritePersonsController < ApplicationController
+  def index
+    @user = current_user
+    @favorite_persons = FavoritePerson.where(user_id: @user.id).all
+  end
+
+  def create
+    favorite_person = current_user.favorite_persons.create(producer_id: params[:producer_id])
+    redirect_to products_url, notice: "生産者をお気に入り登録しました"
+  end
+
+  def destroy
+    favorite_person = current_user.favorite_persons.find_by(id: params[:id]).destroy
+    redirect_to products_url, notice: "生産者のお気に入りを解除しました"
+  end
+
+end

--- a/app/controllers/producers_controller.rb
+++ b/app/controllers/producers_controller.rb
@@ -1,5 +1,9 @@
 class ProducersController < ApplicationController
   def show
     @producer = Producer.find(params[:id])
+
+    if user_signed_in?
+      @favorite_person = current_user.favorite_persons.find_by(producer_id: @producer.id)
+    end
   end
 end

--- a/app/helpers/favorite_persons_helper.rb
+++ b/app/helpers/favorite_persons_helper.rb
@@ -1,0 +1,2 @@
+module FavoritePersonsHelper
+end

--- a/app/models/favorite_person.rb
+++ b/app/models/favorite_person.rb
@@ -1,0 +1,4 @@
+class FavoritePerson < ApplicationRecord
+  belongs_to :user
+  belongs_to :producer
+end

--- a/app/models/producer.rb
+++ b/app/models/producer.rb
@@ -13,5 +13,7 @@ class Producer < ApplicationRecord
 
   has_many :products
   has_many :rooms
+  has_many :favorite_persons, dependent: :destroy
+  has_many :favorite_person_users, through: :favorite_persons, source: :user
   has_one_attached :producer_avatar
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,5 +26,6 @@ class User < ApplicationRecord
    has_one :credit_card, dependent: :destroy
    has_many :rooms
    has_many :favorites, dependent: :destroy
+   has_many :favorite_persons, dependent: :destroy
    has_one_attached :avatar
 end

--- a/app/views/favorite_persons/index.html.erb
+++ b/app/views/favorite_persons/index.html.erb
@@ -1,16 +1,23 @@
 <div class="container">
   <br/>
-  <h3>お気に入り一覧</h3>
+  <h3 class="home_title text-center">お気に入り生産者一覧</h3>
   <br/>
-  <div class="row">
-  <% @favorite_persons.each  do |favorite_person| %>
-    <tr>
-      <div class="box">
-        <%= link_to producer_path(favorite_person.producer.id) do%>
-          <%= favorite_person.producer.producer_name %>
-        <% end %>
-      </div>
-    </tr>
-  <% end %>
+  <div class="col">
+    <div class="row">
+    <% @favorite_persons.each  do |favorite_person| %>
+      <tr>
+        <div class="card ml-2 mb-2 mr-2 rounded border-primary" style="width: 13rem;">
+          <% if favorite_person.producer.producer_avatar.attached?%>
+            <%= image_tag favorite_person.producer.producer_avatar.variant(combine_options:{gravity: :center,border:'2', resize:"180x180^",crop:"220x220+0+0"}).processed ,class: "rounded"%>
+          <% end %>
+          <div class="box ml-2 mb-2 mr-2">
+            <%= link_to producer_path(favorite_person.producer.id) do%>
+              <%= favorite_person.producer.producer_name %>
+            <% end %>
+          </div>
+        </div>
+      </tr>
+    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/favorite_persons/index.html.erb
+++ b/app/views/favorite_persons/index.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <br/>
+  <h3>お気に入り一覧</h3>
+  <br/>
+  <div class="row">
+  <% @favorite_persons.each  do |favorite_person| %>
+    <tr>
+      <div class="box">
+        <%= link_to producer_path(favorite_person.producer.id) do%>
+          <%= favorite_person.producer.producer_name %>
+        <% end %>
+      </div>
+    </tr>
+  <% end %>
+  </div>
+</div>

--- a/app/views/producers/show.html.erb
+++ b/app/views/producers/show.html.erb
@@ -1,6 +1,6 @@
 <br>
-<div class="mx-auto p-4 border border-primary rounded" style="border:solid 1px #343a40; max-width:700px;">
-  <h2>生産者プロフィール画面</h2><br/>
+<div class="mx-auto p-4 border border-primary rounded" style="border:solid 1px #343a40; max-width:500px;">
+  <h3 class="home_title text-center">生産者プロフィール画面</h3><br/>
   <% if @producer.producer_avatar.attached? %>
     <%= image_tag @producer.producer_avatar.variant(combine_options:{gravity: :center,
                                                         border:'2',
@@ -12,8 +12,7 @@
   <h5>生産者名</h5>
   <p class="form-control alert alert-warning rounded"><%= @producer.producer_name %></p>
   <h5>生産者メールアドレス</h5>
-  <p class="form-control alert alert-warning rounded"><%= @producer.email %></p><br/><br/>
-  <br>
+  <p class="form-control alert alert-warning rounded"><%= @producer.email %></p><br/>
   <% if user_signed_in? %>
     <% if @favorite_person.present? %>
       <%= link_to 'お気に入り解除する', favorite_person_path(id: @favorite_person.id), method: :delete, class: 'btn btn-danger' %>
@@ -22,4 +21,54 @@
     <% end %><br/>
   <% end %>
   <br>
+  <div class="text-primary" style="margin-bottom:30px;">
+    <h5 class="home_title text-center">商品一覧</h5>
+  </div>
+  <div class="col">
+    <div class="row">
+      <% @producer.products.each do |product|%>
+        <tr>
+          <div class="card ml-2 mb-2 mr-2 rounded border-primary" style="width: 13rem;">
+            <% if product.image.attached? %>
+              <td><%= image_tag product.image.variant(combine_options:{gravity: :center,border:'2', resize:"180x180^",crop:"220x220+0+0"}).processed ,class: "rounded"%></td>
+            <% end %>
+            <div class="card-body">
+              <div class="example">
+                <div class="box">
+                  <%= link_to producer_path(product.producer.id) do%>
+                    <%= product.producer.producer_name %>
+                  <% end %>
+                </div>
+                <% if product.producer.producer_avatar.attached? %>
+                  <% if product.quantity == 0%>
+                  <p>soldout</p>
+                  <% end %>
+                <% end %>
+              </div>
+              <td>
+                <%= link_to product_path(product.id) do%>
+                  <%= product.title.truncate(20) %>
+                <% end %>
+              </td><br/>
+              <td><h5 class="text-primary">¥ <%= product.price %></h5></td>
+              <td><%= product.content.truncate(23) %></td><br/>
+              <% if current_user.try(:admin?) || producer_signed_in? %>
+                <% if current_user.try(:admin?) || current_producer.id == product.producer.id%>
+                  <td><%= link_to "編集", edit_product_path(product.id) , class: "btn btn-primary mb-1" %></td>
+                <% end %>
+              <% end %>
+              <% if current_user.try(:admin?) %>
+                <td><%= link_to '削除', product_path(product.id), method: :delete , data: { confirm: '本当に削除していいですか？' } , class: "btn btn-primary mb-1" %></td><br/>
+              <% end %>
+              <td class="product_label">
+                <% product.labels.each do |label| %>
+                  <label class='btn-sticky'><%= label.name %></label>
+                <% end %>
+              </td>
+            </div>
+          </div>
+        </tr>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/producers/show.html.erb
+++ b/app/views/producers/show.html.erb
@@ -13,4 +13,13 @@
   <p class="form-control alert alert-warning rounded"><%= @producer.producer_name %></p>
   <h5>生産者メールアドレス</h5>
   <p class="form-control alert alert-warning rounded"><%= @producer.email %></p><br/><br/>
+  <br>
+  <% if user_signed_in? %>
+    <% if @favorite_person.present? %>
+      <%= link_to 'お気に入り解除する', favorite_person_path(id: @favorite_person.id), method: :delete, class: 'btn btn-danger' %>
+    <% else %>
+      <%= link_to 'お気に入りリストへ', favorite_persons_path(producer_id: @producer.id), method: :post, class: 'btn btn-primary' %>
+    <% end %><br/>
+  <% end %>
+  <br>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,4 +16,5 @@
 
   <%= link_to "編集", edit_user_registration_path , class: "btn btn-info"%>
   <%= link_to "お気に入りリスト", favorites_path , class: "btn btn-info"%>
+  <%= link_to "生産者お気に入りリスト", favorite_persons_path , class: "btn btn-info"%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,10 @@ Rails.application.routes.draw do
     end
   end
 
-  #お気に入り
+  #商品のお気に入り
+  resources :favorite_persons, only: %i[create destroy index]
+
+  #生産者のお気に入り
   resources :favorites, only: %i[create destroy index]
 
   #メッセージ一覧画面

--- a/db/migrate/20201002061453_create_favorite_people.rb
+++ b/db/migrate/20201002061453_create_favorite_people.rb
@@ -1,0 +1,10 @@
+class CreateFavoritePeople < ActiveRecord::Migration[5.2]
+  def change
+    create_table :favorite_people do |t|
+      t.integer :user_id
+      t.integer :producer_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_081959) do
+ActiveRecord::Schema.define(version: 2020_10_02_061453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,13 @@ ActiveRecord::Schema.define(version: 2020_08_19_081959) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_comments_on_product_id"
+  end
+
+  create_table "favorite_people", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "producer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "favorites", force: :cascade do |t|

--- a/spec/factories/favorite_people.rb
+++ b/spec/factories/favorite_people.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite_person do
+    user_id { 1 }
+    producer_id { 1 }
+  end
+end

--- a/spec/models/favorite_person_spec.rb
+++ b/spec/models/favorite_person_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FavoritePerson, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
<h2>消費者が生産者をお気に入りリストに入れられるようにする</h2>

 #99

- [x] 消費者が気に入った生産者に対してお気に入りボタンを押すと、ユーザープロフィールからボタンをお気に入りボタンを押した生産者の一覧が閲覧できるようにする。
- [x] 生産者プロフィールページに自身が出品した商品が一覧で見られるようにする。